### PR TITLE
Fix issue #4: Restrict Multiple Votes Per Signer

### DIFF
--- a/anchor/Anchor.toml
+++ b/anchor/Anchor.toml
@@ -6,13 +6,13 @@ resolution = true
 skip-lint = false
 
 [programs.localnet]
-voting = "coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF"
+voting = "F69hmYgN88iUHSmcjF74sJtB4UCDjMyq9ZsExJj1swSp"
 
 [registry]
 url = "https://api.apr.dev"
 
 [provider]
-cluster = "Localnet"
+cluster = "devnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]

--- a/anchor/programs/voting/Cargo.toml
+++ b/anchor/programs/voting/Cargo.toml
@@ -17,4 +17,4 @@ no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]
-anchor-lang = "0.30.1"
+anchor-lang = { version = "0.30.1", features = ["init-if-needed"] }

--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -2,18 +2,19 @@
 
 use anchor_lang::prelude::*;
 
-declare_id!("coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF");
+declare_id!("F69hmYgN88iUHSmcjF74sJtB4UCDjMyq9ZsExJj1swSp");
 
 #[program]
 pub mod voting {
     use super::*;
 
-    pub fn initialize_poll(ctx: Context<InitializePoll>, 
-                            poll_id: u64,
-                            description: String,
-                            poll_start: u64,
-                            poll_end: u64) -> Result<()> {
-
+    pub fn initialize_poll(
+        ctx: Context<InitializePoll>,
+        poll_id: u64,
+        description: String,
+        poll_start: u64,
+        poll_end: u64
+    ) -> Result<()> {
         let poll = &mut ctx.accounts.poll;
         poll.poll_id = poll_id;
         poll.description = description;
@@ -23,10 +24,11 @@ pub mod voting {
         Ok(())
     }
 
-    pub fn initialize_candidate(ctx: Context<InitializeCandidate>, 
-                                candidate_name: String,
-                                _poll_id: u64
-                            ) -> Result<()> {
+    pub fn initialize_candidate(
+        ctx: Context<InitializeCandidate>,
+        candidate_name: String,
+        _poll_id: u64
+    ) -> Result<()> {
         let candidate = &mut ctx.accounts.candidate;
         candidate.candidate_name = candidate_name;
         candidate.candidate_votes = 0;
@@ -34,14 +36,20 @@ pub mod voting {
     }
 
     pub fn vote(ctx: Context<Vote>, _candidate_name: String, _poll_id: u64) -> Result<()> {
+        let voter = &mut ctx.accounts.voter;
+
+        require!(!voter.has_voted, ErrorCode::AlreadyVoted);
+
         let candidate = &mut ctx.accounts.candidate;
         candidate.candidate_votes += 1;
 
+        voter.has_voted = true;
+
         msg!("Voted for candidate: {}", candidate.candidate_name);
-        msg!("Votes: {}", candidate.candidate_votes);
+        msg!("Total votes for {}: {}", candidate.candidate_name, candidate.candidate_votes);
+
         Ok(())
     }
-
 }
 
 #[derive(Accounts)]
@@ -50,22 +58,27 @@ pub struct Vote<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
 
-    #[account(
-        seeds = [poll_id.to_le_bytes().as_ref()],
-        bump
-      )]
+    #[account(seeds = [poll_id.to_le_bytes().as_ref()], bump)]
     pub poll: Account<'info, Poll>,
 
     #[account(
-      mut,
-      seeds = [poll_id.to_le_bytes().as_ref(), candidate_name.as_ref()],
-      bump
+        mut,
+        seeds = [poll_id.to_le_bytes().as_ref(), candidate_name.as_ref()],
+        bump
     )]
     pub candidate: Account<'info, Candidate>,
 
+    #[account(
+        init_if_needed,
+        payer = signer,
+        space = 8 + Voter::INIT_SPACE,
+        seeds = [b"voter", signer.key().as_ref(), poll_id.to_le_bytes().as_ref()],
+        bump
+    )]
+    pub voter: Account<'info, Voter>,
+
     pub system_program: Program<'info, System>,
 }
-
 
 #[derive(Accounts)]
 #[instruction(candidate_name: String, poll_id: u64)]
@@ -73,21 +86,36 @@ pub struct InitializeCandidate<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
 
-    #[account(
-        mut,
-        seeds = [poll_id.to_le_bytes().as_ref()],
-        bump
-      )]
+    #[account(mut, seeds = [poll_id.to_le_bytes().as_ref()], bump)]
     pub poll: Account<'info, Poll>,
 
     #[account(
-      init,
-      payer = signer,
-      space = 8 + Candidate::INIT_SPACE,
-      seeds = [poll_id.to_le_bytes().as_ref(), candidate_name.as_ref()],
-      bump
+        init,
+        payer = signer,
+        space = 8 + Candidate::INIT_SPACE,
+        seeds = [poll_id.to_le_bytes().as_ref(), candidate_name.as_ref()],
+        bump
     )]
     pub candidate: Account<'info, Candidate>,
+
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+#[instruction(poll_id: u64)]
+pub struct InitializePoll<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+
+    #[account(
+        init,
+        payer = signer,
+        space = 8 + Poll::INIT_SPACE,
+        seeds = [poll_id.to_le_bytes().as_ref()],
+        bump
+    )]
+    pub poll: Account<'info, Poll>,
+
     pub system_program: Program<'info, System>,
 }
 
@@ -99,22 +127,6 @@ pub struct Candidate {
     pub candidate_votes: u64,
 }
 
-#[derive(Accounts)]
-#[instruction(poll_id: u64)]
-pub struct InitializePoll<'info> {
-    #[account(mut)]
-    pub signer: Signer<'info>,
-    #[account(
-      init,
-      payer = signer,
-      space = 8 + Poll::INIT_SPACE,
-      seeds = [poll_id.to_le_bytes().as_ref()],
-      bump
-    )]
-    pub poll: Account<'info, Poll>,
-    pub system_program: Program<'info, System>,
-}
-
 #[account]
 #[derive(InitSpace)]
 pub struct Poll {
@@ -124,4 +136,16 @@ pub struct Poll {
     pub poll_start: u64,
     pub poll_end: u64,
     pub candidate_amount: u64,
+}
+
+#[account]
+#[derive(InitSpace)]
+pub struct Voter {
+    pub has_voted: bool,
+}
+
+#[error_code]
+pub enum ErrorCode {
+    #[msg("You have already voted.")]
+    AlreadyVoted,
 }

--- a/anchor/target/idl/voting.json
+++ b/anchor/target/idl/voting.json
@@ -1,5 +1,5 @@
 {
-  "address": "coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF",
+  "address": "F69hmYgN88iUHSmcjF74sJtB4UCDjMyq9ZsExJj1swSp",
   "metadata": {
     "name": "voting",
     "version": "0.1.0",
@@ -169,6 +169,32 @@
           }
         },
         {
+          "name": "voter",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  111,
+                  116,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              },
+              {
+                "kind": "arg",
+                "path": "poll_id"
+              }
+            ]
+          }
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -211,6 +237,26 @@
         153,
         111
       ]
+    },
+    {
+      "name": "Voter",
+      "discriminator": [
+        241,
+        93,
+        35,
+        191,
+        254,
+        147,
+        17,
+        202
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "AlreadyVoted",
+      "msg": "You have already voted."
     }
   ],
   "types": [
@@ -254,6 +300,18 @@
           {
             "name": "candidate_amount",
             "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Voter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "has_voted",
+            "type": "bool"
           }
         ]
       }

--- a/anchor/target/types/voting.ts
+++ b/anchor/target/types/voting.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/voting.json`.
  */
 export type Voting = {
-  "address": "coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF",
+  "address": "F69hmYgN88iUHSmcjF74sJtB4UCDjMyq9ZsExJj1swSp",
   "metadata": {
     "name": "voting",
     "version": "0.1.0",
@@ -175,6 +175,32 @@ export type Voting = {
           }
         },
         {
+          "name": "voter",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  111,
+                  116,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              },
+              {
+                "kind": "arg",
+                "path": "pollId"
+              }
+            ]
+          }
+        },
+        {
           "name": "systemProgram",
           "address": "11111111111111111111111111111111"
         }
@@ -217,6 +243,26 @@ export type Voting = {
         153,
         111
       ]
+    },
+    {
+      "name": "voter",
+      "discriminator": [
+        241,
+        93,
+        35,
+        191,
+        254,
+        147,
+        17,
+        202
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "alreadyVoted",
+      "msg": "You have already voted."
     }
   ],
   "types": [
@@ -260,6 +306,18 @@ export type Voting = {
           {
             "name": "candidateAmount",
             "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "voter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "hasVoted",
+            "type": "bool"
           }
         ]
       }


### PR DESCRIPTION
fixed #4 

## Solution
- Implemented a validation mechanism to check if a signer has already voted.
- If a signer tries to vote again, the transaction will be rejected.
- Updated the voting logic to enforce the **one-vote-per-signer** rule.

Program Id: F69hmYgN88iUHSmcjF74sJtB4UCDjMyq9ZsExJj1swSp

Trx: 5tQnZgNDiJe94iYW4W6UP54mHTEqPbaJS473Smhj4oT6FFtvbkh5ugSDSrpsQdwyTDrFJcjYZGeyTNgYd6JHmYq8

**Registered Email:** anasali12665@gmail.com

![image](https://github.com/user-attachments/assets/416272af-4bcb-4faa-a888-57cd266b6157)
