### PR TITLE
Fix issue #3 : Added Unix timestamp validation and test cases

### DIFF
--- a/anchor/Anchor.toml
+++ b/anchor/Anchor.toml
@@ -6,13 +6,13 @@ resolution = true
 skip-lint = false
 
 [programs.localnet]
-voting = "coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF"
+voting = "F69hmYgN88iUHSmcjF74sJtB4UCDjMyq9ZsExJj1swSp"
 
 [registry]
 url = "https://api.apr.dev"
 
 [provider]
-cluster = "Localnet"
+cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]

--- a/anchor/target/idl/voting.json
+++ b/anchor/target/idl/voting.json
@@ -1,5 +1,5 @@
 {
-  "address": "coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF",
+  "address": "F69hmYgN88iUHSmcjF74sJtB4UCDjMyq9ZsExJj1swSp",
   "metadata": {
     "name": "voting",
     "version": "0.1.0",
@@ -211,6 +211,23 @@
         153,
         111
       ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InvalidPollStart",
+      "msg": "Poll start time must be in the future."
+    },
+    {
+      "code": 6001,
+      "name": "InvalidPollEnd",
+      "msg": "Poll end time must be in the future and after the poll start."
+    },
+    {
+      "code": 6002,
+      "name": "InvalidUnixTimestamp",
+      "msg": "Provided value is not a valid Unix timestamp."
     }
   ],
   "types": [

--- a/anchor/target/types/voting.ts
+++ b/anchor/target/types/voting.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/voting.json`.
  */
 export type Voting = {
-  "address": "coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF",
+  "address": "F69hmYgN88iUHSmcjF74sJtB4UCDjMyq9ZsExJj1swSp",
   "metadata": {
     "name": "voting",
     "version": "0.1.0",
@@ -217,6 +217,23 @@ export type Voting = {
         153,
         111
       ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "invalidPollStart",
+      "msg": "Poll start time must be in the future."
+    },
+    {
+      "code": 6001,
+      "name": "invalidPollEnd",
+      "msg": "Poll end time must be in the future and after the poll start."
+    },
+    {
+      "code": 6002,
+      "name": "invalidUnixTimestamp",
+      "msg": "Provided value is not a valid Unix timestamp."
     }
   ],
   "types": [

--- a/anchor/tests/voting.spec.ts
+++ b/anchor/tests/voting.spec.ts
@@ -10,6 +10,8 @@ describe("Voting", () => {
   let context;
   let provider;
   let votingProgram: anchor.Program<Voting>;
+  let voterKeypair: Keypair;
+  let now: number;
 
   beforeAll(async () => {
     context = await startAnchor('', [{ name: "voting", programId: PROGRAM_ID }], []);
@@ -18,14 +20,93 @@ describe("Voting", () => {
       IDL,
       provider,
     );
+    voterKeypair = Keypair.generate();
+    now = Math.floor(Date.now() / 1000);
   });
 
-  it("initializes a poll", async () => {
+  it("fails to initialize a poll with past poll_start", async () => {
+    try {
+      await votingProgram.methods.initializePoll(
+        new anchor.BN(1),
+        "Invalid Poll Start",
+        new anchor.BN(now - 100), 
+        new anchor.BN(now + 500),
+      ).rpc();
+      throw new Error("Should not allow initializing a poll with a past start time.");
+    } catch (error: any) {
+      expect(error.message).toContain("Poll start time must be in the future");
+    }
+  });
+
+  it("fails to initialize a poll with past poll_end", async () => {
+    try {
+      await votingProgram.methods.initializePoll(
+        new anchor.BN(2),
+        "Invalid Poll End",
+        new anchor.BN(now + 100),
+        new anchor.BN(now - 100), // Past time
+      ).rpc();
+      throw new Error("Should not allow initializing a poll with a past end time.");
+    } catch (error: any) {
+      expect(error.message).toContain("Poll end time must be in the future");
+    }
+  });
+
+  it("fails to initialize a poll with poll_end before poll_start", async () => {
+    try {
+      await votingProgram.methods.initializePoll(
+        new anchor.BN(3),
+        "End before Start",
+        new anchor.BN(now + 300),
+        new anchor.BN(now + 200), 
+      ).rpc();
+      throw new Error("Should not allow initializing a poll with an end time before start time.");
+    } catch (error: any) {
+      expect(error.message).toContain("Poll end time must be in the future and after the poll start");
+    }
+  });
+
+  it("fails to initialize a poll if poll_start is not a valid Unix timestamp", async () => {
+    try {
+      await votingProgram.methods.initializePoll(
+        new anchor.BN(4),
+        "Invalid Start Timestamp",
+        new anchor.BN(999999999), 
+        new anchor.BN(now + 1000),
+      ).rpc();
+
+      fail("Should not allow poll_start to be an invalid Unix timestamp.");
+    } catch (error: any) {
+      expect(error.message).toMatch(/(Provided value is not a valid Unix timestamp|Poll start time must be in the future.)/);
+
+    }
+  });
+
+  it("fails to initialize a poll if poll_end is not a valid Unix timestamp", async () => {
+    try {
+      await votingProgram.methods.initializePoll(
+        new anchor.BN(5),
+        "Invalid End Timestamp",
+        new anchor.BN(now + 100),
+        new anchor.BN(4_000_000_001), 
+      ).rpc();
+
+      fail("Should not allow poll_end to be an invalid Unix timestamp.");
+    } catch (error: any) {
+      expect(error.message).toContain("Provided value is not a valid Unix timestamp.");
+    }
+  });
+
+
+
+  it("successfully initializes a poll", async () => {
+    let start = new anchor.BN(now + 100);
+    let end =  new anchor.BN(now + 1000);
     await votingProgram.methods.initializePoll(
       new anchor.BN(1),
       "What is your favorite color?",
-      new anchor.BN(100),
-      new anchor.BN(1739370789),
+      start,
+      end,
     ).rpc();
 
     const [pollAddress] = PublicKey.findProgramAddressSync(
@@ -39,7 +120,8 @@ describe("Voting", () => {
 
     expect(poll.pollId.toNumber()).toBe(1);
     expect(poll.description).toBe("What is your favorite color?");
-    expect(poll.pollStart.toNumber()).toBe(100);
+    expect(poll.pollStart.toNumber()).toBe(start.toNumber());
+
   });
 
   it("initializes candidates", async () => {


### PR DESCRIPTION


- [x]  Added validation for poll_start and poll_end to check if they fall within the Unix timestamp range (1,000,000,000 to 4,000,000,000).
- [x] Updated the initialize_poll function to enforce the new validation.
- [x] Created test cases to ensure invalid timestamps are rejected.
- [x] Improved error handling messages for clarity.


Email: anasali12665@gmail.com

![image](https://github.com/user-attachments/assets/680823b5-cbe3-4a60-9cac-37c57c3cf3e3)
