### PR TITLE
Fixed #1: initialize_candidate to Properly Update Poll Account

### DIFF
--- a/anchor/Anchor.toml
+++ b/anchor/Anchor.toml
@@ -6,7 +6,7 @@ resolution = true
 skip-lint = false
 
 [programs.localnet]
-voting = "coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF"
+voting = "F69hmYgN88iUHSmcjF74sJtB4UCDjMyq9ZsExJj1swSp"
 
 [registry]
 url = "https://api.apr.dev"

--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -2,7 +2,7 @@
 
 use anchor_lang::prelude::*;
 
-declare_id!("coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF");
+declare_id!("F69hmYgN88iUHSmcjF74sJtB4UCDjMyq9ZsExJj1swSp");
 
 #[program]
 pub mod voting {
@@ -24,14 +24,19 @@ pub mod voting {
     }
 
     pub fn initialize_candidate(ctx: Context<InitializeCandidate>, 
-                                candidate_name: String,
-                                _poll_id: u64
-                            ) -> Result<()> {
-        let candidate = &mut ctx.accounts.candidate;
-        candidate.candidate_name = candidate_name;
-        candidate.candidate_votes = 0;
-        Ok(())
-    }
+      candidate_name: String,
+      _poll_id: u64) -> Result<()> {
+let candidate = &mut ctx.accounts.candidate;
+candidate.candidate_name = candidate_name;
+candidate.candidate_votes = 0;
+
+// Update the candidate amount in the poll account
+let poll = &mut ctx.accounts.poll;
+poll.candidate_amount += 1;
+
+Ok(())
+}
+
 
     pub fn vote(ctx: Context<Vote>, _candidate_name: String, _poll_id: u64) -> Result<()> {
         let candidate = &mut ctx.accounts.candidate;

--- a/anchor/target/idl/voting.json
+++ b/anchor/target/idl/voting.json
@@ -1,5 +1,5 @@
 {
-  "address": "coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF",
+  "address": "F69hmYgN88iUHSmcjF74sJtB4UCDjMyq9ZsExJj1swSp",
   "metadata": {
     "name": "voting",
     "version": "0.1.0",

--- a/anchor/target/types/voting.ts
+++ b/anchor/target/types/voting.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/voting.json`.
  */
 export type Voting = {
-  "address": "coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF",
+  "address": "F69hmYgN88iUHSmcjF74sJtB4UCDjMyq9ZsExJj1swSp",
   "metadata": {
     "name": "voting",
     "version": "0.1.0",

--- a/anchor/tests/voting.spec.ts
+++ b/anchor/tests/voting.spec.ts
@@ -40,9 +40,11 @@ describe("Voting", () => {
     expect(poll.pollId.toNumber()).toBe(1);
     expect(poll.description).toBe("What is your favorite color?");
     expect(poll.pollStart.toNumber()).toBe(100);
+    expect(poll.candidateAmount.toNumber()).toBe(0); // Ensure initial candidate count is 0
   });
 
   it("initializes candidates", async () => {
+    // Initialize candidates
     await votingProgram.methods.initializeCandidate(
       "Pink",
       new anchor.BN(1),
@@ -51,6 +53,15 @@ describe("Voting", () => {
       "Blue",
       new anchor.BN(1),
     ).rpc();
+
+    const [pollAddress] = PublicKey.findProgramAddressSync(
+      [new anchor.BN(1).toArrayLike(Buffer, "le", 8)],
+      votingProgram.programId,
+    );
+    const poll = await votingProgram.account.poll.fetch(pollAddress);
+
+    // Ensure candidate count is updated
+    expect(poll.candidateAmount.toNumber()).toBe(2);
 
     const [pinkAddress] = PublicKey.findProgramAddressSync(
       [new anchor.BN(1).toArrayLike(Buffer, "le", 8), Buffer.from("Pink")],


### PR DESCRIPTION
fixed #1

Currently, when a new candidate is initialized using the initialize_candidate function, the poll account is not updated, leading to inaccurate data.

This PR modifies the function to ensure the poll account reflects the change, either by incrementing the candidate count or adding the new candidate to a list

Email: anasali12665@gmail.com

![image](https://github.com/user-attachments/assets/f8b88231-8bcf-4eaa-8aa9-e386dd430939)


. 
 This pull request was created for https://app.gib.work/bounties/d3c27932-7809-4a46-be74-e4a78ebb861e in an attempt to solve a bounty #1 . Payment for the bounty is immediately sent to the contributor after merge.